### PR TITLE
Fix statement separation in Turtle serialization

### DIFF
--- a/public/play/play.js
+++ b/public/play/play.js
@@ -435,7 +435,12 @@
           //console.log(o);
           // print the object
           if(o.type == RDF_PLAIN_LITERAL) {
-             rval += '"' + o.value.replace('"', '\\"') + '"';
+             var lit = o.value.replace('"', '\\"');
+             var sep = '"';
+             if (lit.indexOf('\n') > -1) {
+               sep = '"""';
+             }
+             rval += sep + lit + sep;
              if(o.language != null) {
                 rval += '@' + o.language;
              }


### PR DESCRIPTION
Ensure that the last statement about a subject is terminated by a dot (to make the raw data valid as Turtle).
