### PR TITLE
Added test cases for processor warnings and fixed test case 311

### DIFF
--- a/manifest.ttl
+++ b/manifest.ttl
@@ -2498,4 +2498,34 @@ white   space
    """;
    test:specificationReference "" .
 
+<test-cases/0314> dc:contributor "Lev Khomich";
+   dc:title "rdfagraph='processor' should generate rdfa:UnresolvedCURIE warning when it fails to resolve CURIE prefix";
+   a test:TestCase;
+   rdfatest:rdfaVersion "rdfa1.1-proc";
+   test:classification test:required;
+   rdfatest:hostLanguage "xml", "xhtml1", "html4", "html5", "xhtml5", "svg";
+   rdfatest:queryParam "rdfagraph=processor";
+   test:informationResourceInput <test-cases/0314.html>;
+   test:informationResourceResults <test-cases/0314.sparql>;
+   test:purpose """
+      Setting rdfagraph query parameter to 'processor' generates an rdfa:UnresolvedCURIE warning when 
+      it fails to resolve CURIE prefix.
+   """;
+   test:specificationReference "RDFa Vocabulary for Term and Prefix Assignment, and for Processor Graph Reporting" .
+
+<test-cases/0315> dc:contributor "Lev Khomich";
+   dc:title "rdfagraph='processor' should generate rdfa:UnresolvedTerm warning when it fails to resolve Term";
+   a test:TestCase;
+   rdfatest:rdfaVersion "rdfa1.1-proc";
+   test:classification test:required;
+   rdfatest:hostLanguage "xml", "xhtml1", "html4", "html5", "xhtml5", "svg";
+   rdfatest:queryParam "rdfagraph=processor";
+   test:informationResourceInput <test-cases/0315.html>;
+   test:informationResourceResults <test-cases/0315.sparql>;
+   test:purpose """
+      Setting rdfagraph query parameter to 'processor' generates an rdfa:UnresolvedTerm warning when 
+      it fails to resolve Term.
+   """;
+   test:specificationReference "RDFa Vocabulary for Term and Prefix Assignment, and for Processor Graph Reporting" .
+
 

--- a/tests/0311.txt
+++ b/tests/0311.txt
@@ -1,4 +1,3 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
 <head>
 	<title>Test 0311</title>
 </head>

--- a/tests/0314.sparql
+++ b/tests/0314.sparql
@@ -1,0 +1,2 @@
+PREFIX rdfa: <http://www.w3.org/ns/rdfa#>
+ASK WHERE { ?s a rdfa:UnresolvedCURIE }

--- a/tests/0314.txt
+++ b/tests/0314.txt
@@ -1,0 +1,6 @@
+<head>
+  <title>Test 0314</title>
+</head>
+<body>
+  	<span about="http://example.org/something" property="unknown:property" content="value" />
+</body>

--- a/tests/0315.sparql
+++ b/tests/0315.sparql
@@ -1,0 +1,2 @@
+PREFIX rdfa: <http://www.w3.org/ns/rdfa#>
+ASK WHERE { ?s a rdfa:UnresolvedTerm }

--- a/tests/0315.txt
+++ b/tests/0315.txt
@@ -1,0 +1,8 @@
+<head>
+  <title>Test 0315</title>
+</head>
+<body>
+    <div about="http://example.org/something">
+      <p rel="unknown" resource="http://example.org/Bender">That's impossible</p>
+    </div>
+</body>


### PR DESCRIPTION
Added test cases for processor warnings: rdfa:UnresolvedCURIE and rdfa:UnresolvedTerm.
I think test case 311 shouldn't redefin dc: prefix because that generates rdfa:PrefixRedefinition warning, but ASK can not properly check results. So I removed prefix mapping (btw it wasn't used in test case at all).
