### PR TITLE
Handling XMLLiterals in play

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /tmp
 /vendor
 /config.ru
+
+.DS_Store

--- a/public/play/play.js
+++ b/public/play/play.js
@@ -7,6 +7,7 @@
   RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
   RDF_PLAIN_LITERAL = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral';
   RDF_TYPED_LITERAL = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#TypedLiteral';
+  RDF_XML_LITERAL = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral';
   RDF_OBJECT = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#object';
 
   // create the play instance if it doesn't already exist
@@ -274,6 +275,11 @@
             // if the property is an rdf:type, shorten the IRI
             value = play.getIriShortName(o.value);
           }
+          else if(o.type == RDF_XML_LITERAL)
+          {
+            // if the property is an XMLLiteral, serialise it
+            value = play.nodelistToXMLLiteral(o.value);
+          }
           else
           {
             value = o.value;
@@ -332,6 +338,20 @@
      return rval;
   };
   
+  /**
+   * Converts a NodeList into an rdf:XMLLiteral string.
+   *
+   * @param nodelist the nodelist.
+   */
+  play.nodelistToXMLLiteral = function(nodelist) {
+    var str = '';
+    for(var i = 0; i < nodelist.length; i++) {
+      var n = nodelist[i];
+      str += n.outerHTML || n.nodeValue;
+    }
+    return str;
+  };
+
   /**
    * Converts the RDFa data in the page to a N-Triples representation.
    *
@@ -452,6 +472,11 @@
             else {
               rval += play.iriToCurie(o.value, prefixesUsed);
             }
+          }
+          else if(o.type == RDF_XML_LITERAL) {
+            rval += '"';
+            rval += play.nodelistToXMLLiteral(o.value).replace('"', '\\"');
+            rval += '"^^rdf:XMLLiteral';
           }
           else if(o.type != null) {
             rval += '"' + o.value.replace('"', '\\"') + '"' + '^^' +


### PR DESCRIPTION
Fixing handling of XMLLiterals so that they get mapped to the correct Turtle syntax and show embedded tags when displayed in visualisation. This fixes #16.
