### PR TITLE
@lang and @datatype tests

### DIFF
--- a/manifest.ttl
+++ b/manifest.ttl
@@ -2682,3 +2682,25 @@ white   space
    test:informationResourceResults <test-cases/0329.sparql>;
    test:purpose "Tests recursive triple generation for nested literals.";
    test:specificationReference "N.A." .
+
+<test-cases/0330> dc:contributor "Reece H. Dunn";
+   dc:title "@datatype overrides inherited @lang";
+   a test:TestCase;
+   rdfatest:rdfaVersion "rdfa1.1";
+   test:classification test:required;
+   rdfatest:hostLanguage "xml", "xhtml1", "html4", "html5", "xhtml5";
+   test:informationResourceInput <test-cases/0330.html>;
+   test:informationResourceResults <test-cases/0330.sparql>;
+   test:purpose "Tests @datatype is used instead of @lang when @datatype is not empty (e.g. annotating a date).";
+   test:specificationReference "N.A." .
+
+<test-cases/0331> dc:contributor "Reece H. Dunn";
+   dc:title "@datatype overrides inherited @lang, with @content";
+   a test:TestCase;
+   rdfatest:rdfaVersion "rdfa1.1";
+   test:classification test:required;
+   rdfatest:hostLanguage "xml", "xhtml1", "html4", "html5", "xhtml5";
+   test:informationResourceInput <test-cases/0331.html>;
+   test:informationResourceResults <test-cases/0331.sparql>;
+   test:purpose "Tests @datatype is used instead of @lang when @datatype is not empty, and @content is used for the value (e.g. annotating a language with human and machine readable text).";
+   test:specificationReference "N.A." .

--- a/tests/0330.sparql
+++ b/tests/0330.sparql
@@ -1,0 +1,6 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+ASK WHERE {
+  [ dcterms:date "2010-11-12"^^xsd:date ]
+}

--- a/tests/0330.txt
+++ b/tests/0330.txt
@@ -1,0 +1,8 @@
+   xmlns:dcterms="http://purl.org/dc/terms/"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+<head>
+   <title>Test 0330</title>
+</head>
+<body lang="en">
+  <div property="dc:date" datatype="xsd:date">2010-11-12</div>
+</body>

--- a/tests/0331.sparql
+++ b/tests/0331.sparql
@@ -1,0 +1,5 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+ASK WHERE {
+  [ dcterms:language "af"^^dcterms:RFC5646 ]
+}

--- a/tests/0331.txt
+++ b/tests/0331.txt
@@ -1,0 +1,7 @@
+   xmlns:dcterms="http://purl.org/dc/terms/"
+<head>
+   <title>Test 0331</title>
+</head>
+<body lang="en">
+  <div property="dcterms:language" datatype="dcterms:RFC5646" content="af">Afrikaans</div>
+</body>


### PR DESCRIPTION
This adds two new tests, which both have @lang on a parent node:

0330 -- tests @property+@datatype which passes using RDF::RDFa
0331 -- tests @property+@datatype+@content which fails using RDF::RDFa
