### PR TITLE
For rdfaVersion, give runner part before '-' only

### DIFF
--- a/bin/run-suite
+++ b/bin/run-suite
@@ -67,7 +67,7 @@ def run_tc(tc, runner, options)
       uri = CRAZY_IVAN.send(:get_test_url, version, host_language, tc["num"])
       runner_args = ARGV[0].split(/\s+/) + [
         "--host-language", host_language,
-        "--version", version,
+        "--version", version.split('-')[0],
         "--uri", uri
       ]
   


### PR DESCRIPTION
This causes the *-proc, *-vocab, and *-role tests to pass with bin/rdf-rdfa instead of failing.
