### PR TITLE
Use @prefix for prefix mapping in rdfa1.1 test-case output, and use xmls:foo for rdfa1.0 output.

### DIFF
--- a/tests/0001.txt
+++ b/tests/0001.txt
@@ -1,4 +1,4 @@
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   {"dc": "http://purl.org/dc/elements/1.1/"}
 <head>
    <title>Test 0001</title>
 </head>

--- a/tests/0006.txt
+++ b/tests/0006.txt
@@ -1,5 +1,5 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/",
+       "foaf": "http://xmlns.com/foaf/0.1/"}
 	<head>
 		<title>Test 0006</title>
 	</head>

--- a/tests/0007.txt
+++ b/tests/0007.txt
@@ -1,5 +1,5 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/",
+       "foaf": "http://xmlns.com/foaf/0.1/"}
 	<head>
 		<title>Test 0007</title>
 	</head>

--- a/tests/0008.txt
+++ b/tests/0008.txt
@@ -1,4 +1,4 @@
-  xmlns:cc="http://creativecommons.org/ns#"
+  {"cc": "http://creativecommons.org/ns#"}
 	<head>
 		<title>Test 0008</title>
 	</head>

--- a/tests/0009.txt
+++ b/tests/0009.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
 	<head>
 		<title>Test 0009</title>
     	<link about="http://example.org/people#Person1"

--- a/tests/0010.txt
+++ b/tests/0010.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0010</title>
 	  	<link about="http://example.org/people#Person1"

--- a/tests/0012.txt
+++ b/tests/0012.txt
@@ -1,4 +1,4 @@
-      xmlns:ex="http://example.org/"
+      {"ex": "http://example.org/"}
   <head about="">
 	<title>Test 0012</title>
   	<meta about="http://example.org/node" property="ex:property" xml:lang="fr" content="chat" />

--- a/tests/0013.txt
+++ b/tests/0013.txt
@@ -1,4 +1,4 @@
-      xmlns:ex="http://example.org/"
+      {"ex": "http://example.org/"}
   <head about="" xml:lang="fr">
   	<title xml:lang="en">Test 0013</title>
   	<meta about="http://example.org/node" property="ex:property" content="chat" />

--- a/tests/0014.txt
+++ b/tests/0014.txt
@@ -1,5 +1,5 @@
-      xmlns:ex="http://example.org/"
-      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+      {"ex": "http://example.org/",
+       "xsd": "http://www.w3.org/2001/XMLSchema#"}
 	<head>
 		<title>Test 0014</title>
 	</head>

--- a/tests/0015.txt
+++ b/tests/0015.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
   <head>
 	<title>Test 0015</title>
 	<link rel="dc:source" href="urn:isbn:0140449132" />

--- a/tests/0017.txt
+++ b/tests/0017.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 	<title>Test 0017</title>   
   </head>

--- a/tests/0018.txt
+++ b/tests/0018.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
   <head>
 	<title>Test 0018</title>
   </head>

--- a/tests/0019.txt
+++ b/tests/0019.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 	<title>Test 0019</title>
   </head>

--- a/tests/0020.txt
+++ b/tests/0020.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
   <head>
 	<title>Test 0020</title>
   </head>

--- a/tests/0021.txt
+++ b/tests/0021.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
 <head>
 	<title>Test 0021</title>
 </head>

--- a/tests/0023.txt
+++ b/tests/0023.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
   <head>
 	<title>Test 0023</title>
   </head>

--- a/tests/0025.txt
+++ b/tests/0025.txt
@@ -1,5 +1,5 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/",
+       "foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 	<title>Test 0025</title>
   </head>

--- a/tests/0026.txt
+++ b/tests/0026.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
   <head>
 	<title>Test 0026</title>
   </head>

--- a/tests/0027.txt
+++ b/tests/0027.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
   <head>
    <title>Test 0027</title>
   </head>

--- a/tests/0029.txt
+++ b/tests/0029.txt
@@ -1,5 +1,5 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
-      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+      {"dc": "http://purl.org/dc/elements/1.1/",
+       "xsd": "http://www.w3.org/2001/XMLSchema#"}
   <head>
    <title>Test 0029</title>
   </head>

--- a/tests/0030.txt
+++ b/tests/0030.txt
@@ -1,4 +1,4 @@
-      xmlns:cc="http://creativecommons.org/ns#"
+      {"cc": "http://creativecommons.org/ns#"}
 	<head>
 		<title>Test 0030</title>
 	</head>

--- a/tests/0031.txt
+++ b/tests/0031.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
   <head>
 	<title>Test 0031</title>
   </head>

--- a/tests/0032.txt
+++ b/tests/0032.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
 	<head>
 		<title>Test 0032</title>
 	</head>

--- a/tests/0033.txt
+++ b/tests/0033.txt
@@ -1,5 +1,5 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/",
+       "foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 	<title>Test 0033</title>
   </head>

--- a/tests/0034.txt
+++ b/tests/0034.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0034</title>    
   </head>

--- a/tests/0035.txt
+++ b/tests/0035.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0035</title>    
   </head>

--- a/tests/0036.txt
+++ b/tests/0036.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0036</title>    
   </head>

--- a/tests/0037.txt
+++ b/tests/0037.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0037</title>    
   </head>

--- a/tests/0038.txt
+++ b/tests/0038.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0038</title>    
   </head>

--- a/tests/0039.txt
+++ b/tests/0039.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0039</title>    
   </head>

--- a/tests/0040.txt
+++ b/tests/0040.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0040</title>    
   </head>

--- a/tests/0041.txt
+++ b/tests/0041.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0041</title>    
   </head>

--- a/tests/0042.txt
+++ b/tests/0042.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0042</title>    
   </head>

--- a/tests/0046.txt
+++ b/tests/0046.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0046</title>    
   </head>

--- a/tests/0047.txt
+++ b/tests/0047.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0047</title>    
   </head>

--- a/tests/0048.txt
+++ b/tests/0048.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0048</title>    
   </head>

--- a/tests/0049.txt
+++ b/tests/0049.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0049</title>    
   </head>

--- a/tests/0050.txt
+++ b/tests/0050.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0050</title>    
   </head>

--- a/tests/0051.txt
+++ b/tests/0051.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0051</title>    
   </head>

--- a/tests/0052.txt
+++ b/tests/0052.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0052</title>    
   </head>

--- a/tests/0053.txt
+++ b/tests/0053.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0053</title>    
   </head>

--- a/tests/0054.txt
+++ b/tests/0054.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
   <head>
 		<title>Test 0054</title>    
   </head>

--- a/tests/0055.txt
+++ b/tests/0055.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
   <head>
 		<title>Test 0055</title>    
   </head>

--- a/tests/0056.txt
+++ b/tests/0056.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
     <title>Test 0056</title>
   </head>

--- a/tests/0057.txt
+++ b/tests/0057.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
     <title>Test 0057</title>
   </head>

--- a/tests/0058.txt
+++ b/tests/0058.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
     <title>Test 0058</title>
   </head>

--- a/tests/0059.txt
+++ b/tests/0059.txt
@@ -1,5 +1,5 @@
- 	  xmlns:dc="http://purl.org/dc/elements/1.1/"
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+ 	  {"dc": "http://purl.org/dc/elements/1.1/",
+ 	   "foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
     <title>Test 0059</title>
   </head>

--- a/tests/0060.txt
+++ b/tests/0060.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
     <title>Test 0060</title>
   </head>

--- a/tests/0064.txt
+++ b/tests/0064.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
     <title>Test 0064</title>
   </head>

--- a/tests/0065.txt
+++ b/tests/0065.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
     <title>Test 0065</title>
   </head>

--- a/tests/0066.txt
+++ b/tests/0066.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
    <head typeof="foaf:Document">
       <title>Test 0066</title>
    </head>

--- a/tests/0067.txt
+++ b/tests/0067.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
    <head>
       <title property="foaf:topic">Test 0067</title>
    </head>

--- a/tests/0068.txt
+++ b/tests/0068.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
    <head>
       <title>Test 0068</title>
    </head>

--- a/tests/0069.txt
+++ b/tests/0069.txt
@@ -1,4 +1,4 @@
-      xmlns:xhv="http://www.w3.org/1999/xhtml/vocab#"
+      {"xhv": "http://www.w3.org/1999/xhtml/vocab#"}
    <head>
       <title>Test 0069</title>
    </head>

--- a/tests/0070.txt
+++ b/tests/0070.txt
@@ -1,4 +1,4 @@
-      xmlns:xhv="http://www.w3.org/1999/xhtml/vocab#"
+      {"xhv": "http://www.w3.org/1999/xhtml/vocab#"}
    <head>
       <title>Test 0070</title>
    </head>

--- a/tests/0071.txt
+++ b/tests/0071.txt
@@ -1,4 +1,4 @@
-      xmlns:cc="http://creativecommons.org/ns#"
+      {"cc": "http://creativecommons.org/ns#"}
    <head>
       <title>Test 0071</title>
    </head>

--- a/tests/0072.txt
+++ b/tests/0072.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
    <head>
       <base href="http://www.example.org/"></base>
       <title>Test 0072</title>

--- a/tests/0073.txt
+++ b/tests/0073.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
    <head>
       <base href="http://www.example.org/"></base>
       <title>Test 0073</title>

--- a/tests/0074.txt
+++ b/tests/0074.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
    <head>
       <base href="http://www.example.org/"></base>
       <title>Test 0074</title>

--- a/tests/0075.txt
+++ b/tests/0075.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
    <head>
       <base href="http://www.example.org/"></base>
       <title>Test 0075</title>

--- a/tests/0078.txt
+++ b/tests/0078.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0078</title>    
   </head>

--- a/tests/0079.txt
+++ b/tests/0079.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0079</title>    
   </head>

--- a/tests/0080.txt
+++ b/tests/0080.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0080</title>    
   </head>

--- a/tests/0081.txt
+++ b/tests/0081.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0081</title>    
   </head>

--- a/tests/0082.txt
+++ b/tests/0082.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0082</title>    
   </head>

--- a/tests/0083.txt
+++ b/tests/0083.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0083</title>    
   </head>

--- a/tests/0084.txt
+++ b/tests/0084.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0084</title>    
   </head>

--- a/tests/0085.txt
+++ b/tests/0085.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0085</title>    
   </head>

--- a/tests/0088.txt
+++ b/tests/0088.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0088</title>    
   </head>

--- a/tests/0089.txt
+++ b/tests/0089.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
  <head profile="http://www.w3.org/1999/xhtml/vocab">
       <title>Test 0089</title>
    </head>

--- a/tests/0090.txt
+++ b/tests/0090.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
  <head profile="http://www.w3.org/1999/xhtml/vocab">
       <title>Test 0090</title>
    </head>

--- a/tests/0093.txt
+++ b/tests/0093.txt
@@ -1,5 +1,5 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
-	  xmlns:ex="http://www.example.org/"
+      {"dc": "http://purl.org/dc/elements/1.1/",
+	   "ex": "http://www.example.org/"}
   <head profile="http://www.w3.org/1999/xhtml/vocab">
 	<title>Test 0093</title>
   </head>

--- a/tests/0099.txt
+++ b/tests/0099.txt
@@ -1,4 +1,4 @@
-	  xmlns:example="http://www.example.org/"
+	  {"example": "http://www.example.org/"}
    <head profile="http://www.w3.org/1999/xhtml/vocab">
       <title>Test 0099</title>
    </head>

--- a/tests/0104.txt
+++ b/tests/0104.txt
@@ -1,5 +1,5 @@
-      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-      xmlns:example="http://www.example.org/"
+      {"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+       "example": "http://www.example.org/"}
   <head profile="http://www.w3.org/1999/xhtml/vocab">
 	<title>Test 0104</title>
   </head>

--- a/tests/0106.txt
+++ b/tests/0106.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
   <head>
 	<title>Test 0106</title>
   </head>

--- a/tests/0107.txt
+++ b/tests/0107.txt
@@ -1,4 +1,4 @@
-      xmlns:ex="http://example.org/"
+      {"ex": "http://example.org/"}
   <head>
 	<title>Test 0107</title>
   </head>

--- a/tests/0108.txt
+++ b/tests/0108.txt
@@ -1,4 +1,4 @@
-      xmlns:ex="http://example.org/"
+      {"ex": "http://example.org/"}
   <head>
 	<title>Test 0108</title>
   </head>

--- a/tests/0109.txt
+++ b/tests/0109.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
       xml:base="http://example.org/invalid/"
    <head>
       <title>Test 0109</title>

--- a/tests/0110.txt
+++ b/tests/0110.txt
@@ -1,4 +1,4 @@
-      xmlns:xhv="http://www.w3.org/1999/xhtml/vocab#"
+      {"xhv": "http://www.w3.org/1999/xhtml/vocab#"}
   <head>
         <title>Test 0110</title>
   </head>

--- a/tests/0111.txt
+++ b/tests/0111.txt
@@ -1,4 +1,4 @@
-      xmlns:xhv="http://www.w3.org/1999/xhtml/vocab#"
+      {"xhv": "http://www.w3.org/1999/xhtml/vocab#"}
   <head>
     <title>Test 0111</title>
   </head>

--- a/tests/0112.txt
+++ b/tests/0112.txt
@@ -1,4 +1,4 @@
-      xmlns:ex="http://example.org/"
+      {"ex": "http://example.org/"}
   <head>
 	<title>Test 0112</title>
   </head>

--- a/tests/0113.txt
+++ b/tests/0113.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
   <head>
     <title>Test 0113</title>
   </head>

--- a/tests/0114.txt
+++ b/tests/0114.txt
@@ -1,6 +1,6 @@
-      xmlns:cc="http://creativecommons.org/ns#"
-      xmlns:xhv="http://www.w3.org/1999/xhtml/vocab#"
-      xmlns:rdfatest="http://rdfa.info/vocabs/rdfa-test#"
+      {"cc": "http://creativecommons.org/ns#",
+       "xhv": "http://www.w3.org/1999/xhtml/vocab#",
+       "rdfatest": "http://rdfa.info/vocabs/rdfa-test#"}
   <head>
     <title>Test 0114</title>
   </head>

--- a/tests/0115.txt
+++ b/tests/0115.txt
@@ -1,4 +1,4 @@
-         xmlns:ex="http://www.example.com/"
+         {"ex": "http://www.example.com/"}
    <head>
      <title>Test 0115</title>
    </head>

--- a/tests/0117.txt
+++ b/tests/0117.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
    <head>
       <base href="http://www.example.org/tc117.xhtml#fragment"></base>
       <title property="dc:title">Test 0117</title>

--- a/tests/0118.txt
+++ b/tests/0118.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
    <head>
       <title>Test 0118</title>
    </head>

--- a/tests/0119.txt
+++ b/tests/0119.txt
@@ -1,5 +1,5 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
-      xmlns:example="http://example.org/"
+      {"dc": "http://purl.org/dc/elements/1.1/",
+       "example": "http://example.org/"}
    <head>
       <title>Test 0119</title>
    </head>

--- a/tests/0120.txt
+++ b/tests/0120.txt
@@ -1,5 +1,5 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
-      xmlns:example="http://example.org/"
+      {"dc": "http://purl.org/dc/elements/1.1/",
+       "example": "http://example.org/"}
    <head>
       <title>Test 0120</title>
    </head>

--- a/tests/0121.txt
+++ b/tests/0121.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
    <head>
       <title>Test 0121</title>
    </head>

--- a/tests/0126.txt
+++ b/tests/0126.txt
@@ -1,6 +1,6 @@
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:sioc="http://rdfs.org/sioc/ns#"
-   xmlns:foaf="http://xmlns.com/foaf/0.1/"
+   {"dct": "http://purl.org/dc/terms/",
+    "sioc": "http://rdfs.org/sioc/ns#",
+    "foaf": "http://xmlns.com/foaf/0.1/"}
     <head>
       <title>Test 0126</title>
     </head>

--- a/tests/0131.txt
+++ b/tests/0131.txt
@@ -1,4 +1,4 @@
-      xmlns:xhv="http://www.w3.org/1999/xhtml/vocab#"
+      {"xhv": "http://www.w3.org/1999/xhtml/vocab#"}
 <head>
   <title>Test</title>
   <link rel="xhv:next&#x20;xhv:prev&#x09;xhv:first&#x0a;xhv:last&#x0d;xhv:subsection" href="http://example.org/test.css" />

--- a/tests/0172.txt
+++ b/tests/0172.txt
@@ -1,4 +1,4 @@
-      xmlns:ex="http://example.org/terms#"
+      {"ex": "http://example.org/terms#"}
 <head> 
    <title>Test 0172</title> 
    <base href="http://example.org/"/> 

--- a/tests/0173.txt
+++ b/tests/0173.txt
@@ -1,4 +1,4 @@
-      xmlns:ex="http://example.org/terms#"
+      {"ex": "http://example.org/terms#"}
 <head> 
    <title>Test 0173</title> 
    <base href="http://example.org/"/> 

--- a/tests/0174.txt
+++ b/tests/0174.txt
@@ -1,4 +1,4 @@
-      xmlns:v="http://www.w3.org/2006/vcard/ns#"
+      {"v": "http://www.w3.org/2006/vcard/ns#"}
 <head> 
    <title>Test 0174</title> 
 </head> 

--- a/tests/0176.txt
+++ b/tests/0176.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
     <title>Test 0176</title>
   </head>

--- a/tests/0196.txt
+++ b/tests/0196.txt
@@ -1,5 +1,5 @@
-  xmlns:ex="http://example.org/rdf/"
-  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  {"ex": "http://example.org/rdf/",
+   "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"}
 <head>
 	<title>Test 0196</title>
 </head>

--- a/tests/0197.txt
+++ b/tests/0197.txt
@@ -1,4 +1,4 @@
-  xmlns:dc="http://purl.org/dc/terms/"
+  {"dc": "http://purl.org/dc/terms/"}
 <head>
 	<title>Test 0197</title>
 	<base href="http://www.example.org/me" />

--- a/tests/0198.txt
+++ b/tests/0198.txt
@@ -1,5 +1,5 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
-      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      {"foaf": "http://xmlns.com/foaf/0.1/",
+       "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"}
 <head>
 	<title>Test 0198</title>
 	<base href="http://www.example.org/me" />

--- a/tests/0207.txt
+++ b/tests/0207.txt
@@ -1,5 +1,5 @@
-  xmlns:cal="http://www.w3.org/2002/12/cal/icaltzd#" 
-  xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+  {"cal": "http://www.w3.org/2002/12/cal/icaltzd#",
+   "xsd": "http://www.w3.org/2001/XMLSchema#"}
 <head>
    <title>Test 0207</title>    
 </head>

--- a/tests/0212.txt
+++ b/tests/0212.txt
@@ -1,4 +1,4 @@
-      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
   <head>
 	<title>Test 0212</title>
   </head>

--- a/tests/0213.txt
+++ b/tests/0213.txt
@@ -1,4 +1,4 @@
-      prefix="dc: http://purl.org/dc/elements/1.1/"
+      {"dc": "http://purl.org/dc/elements/1.1/"}
   <head>
 	<title>Test 0213</title>
   </head>

--- a/tests/0215.txt
+++ b/tests/0215.txt
@@ -1,22 +1,22 @@
 
-		  xmlns:air="http://www.daml.org/2001/10/html/airport-ont#"
-		  xmlns:bio="http://vocab.org/bio/0.1/"
-		  xmlns:contact="http://www.w3.org/2000/10/swap/pim/contact#"
-		  xmlns:dc="http://purl.org/dc/terms/"
-		  xmlns:foaf="http://xmlns.com/foaf/0.1/"
-		  xmlns:ical="http://www.w3.org/2002/12/cal/icaltzd#"
-		  xmlns:owl="http://www.w3.org/2002/07/owl#"
-		  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-		  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-		  xmlns:rel="http://vocab.org/relationship/"
-		  xmlns:openid="http://xmlns.openid.net/auth#"
-		  xmlns:rss="http://web.resource.org/rss/1.0/"
-		  xmlns:sioc="http://rdfs.org/sioc/ns#"
-		  xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-		  xmlns:google="http://rdf.data-vocabulary.org/#"
-		  xmlns:rsa="http://www.w3.org/ns/auth/rsa#"
-		  xmlns:cert="http://www.w3.org/ns/auth/cert#"
-		  xmlns:wot="http://xmlns.com/wot/0.1/"
+		  {"air": "http://www.daml.org/2001/10/html/airport-ont#",
+		   "bio": "http://vocab.org/bio/0.1/",
+		   "contact": "http://www.w3.org/2000/10/swap/pim/contact#",
+		   "dc": "http://purl.org/dc/terms/",
+		   "foaf": "http://xmlns.com/foaf/0.1/",
+		   "ical": "http://www.w3.org/2002/12/cal/icaltzd#",
+		   "owl": "http://www.w3.org/2002/07/owl#",
+		   "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+		   "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+		   "rel": "http://vocab.org/relationship/",
+		   "openid": "http://xmlns.openid.net/auth#",
+		   "rss": "http://web.resource.org/rss/1.0/",
+		   "sioc": "http://rdfs.org/sioc/ns#",
+		   "xsd": "http://www.w3.org/2001/XMLSchema#",
+		   "google": "http://rdf.data-vocabulary.org/#",
+		   "rsa": "http://www.w3.org/ns/auth/rsa#",
+		   "cert": "http://www.w3.org/ns/auth/cert#",
+		   "wot": "http://xmlns.com/wot/0.1/"}
 <head>
    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
 </head>

--- a/tests/0229.txt
+++ b/tests/0229.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0042</title>    
   </head>

--- a/tests/0232.txt
+++ b/tests/0232.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0232</title>    
   </head>

--- a/tests/0233.txt
+++ b/tests/0233.txt
@@ -1,4 +1,4 @@
-      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+      {"foaf": "http://xmlns.com/foaf/0.1/"}
   <head>
 		<title>Test 0233</title>    
   </head>

--- a/tests/0261.txt
+++ b/tests/0261.txt
@@ -1,5 +1,5 @@
-  xmlns:ex="http://example.org/rdf/"
-  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  {"ex": "http://example.org/rdf/",
+   "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"}
 <head>
 	<title>Test 0261</title>
 </head>

--- a/tests/0262.txt
+++ b/tests/0262.txt
@@ -1,4 +1,4 @@
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   {"dc": "http://purl.org/dc/elements/1.1/"}
 <head>
    <title>Test 0262</title>
 </head>

--- a/tests/0291.txt
+++ b/tests/0291.txt
@@ -1,4 +1,4 @@
-  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  {"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"}
 <head>
   <title>Test 0291</title>
 </head>

--- a/tests/0292.txt
+++ b/tests/0292.txt
@@ -1,4 +1,4 @@
-  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  {"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"}
 <head>
   <title>Test 0292</title>
 </head>

--- a/tests/0295.txt
+++ b/tests/0295.txt
@@ -1,30 +1,30 @@
-   xmlns:air="http://www.daml.org/2001/10/html/airport-ont#"
-   xmlns:bio="http://vocab.org/bio/0.1/"
-   xmlns:cal="http://www.w3.org/2002/12/cal/icaltzd#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:cert="http://www.w3.org/ns/auth/cert#"
-   xmlns:contact="http://www.w3.org/2000/10/swap/pim/contact#"
-   xmlns:dc="http://purl.org/dc/terms/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:earl="http://www.w3.org/ns/earl#"
-   xmlns:example="http://example.org/"
-   xmlns:ex="http://example.org/"
-   xmlns:foaf="http://xmlns.com/foaf/0.1/"
-   xmlns:google="http://rdf.data-vocabulary.org/#"
-   xmlns:ical="http://www.w3.org/2002/12/cal/icaltzd#"
-   xmlns:openid="http://xmlns.openid.net/auth#"
-   xmlns:owl="http://www.w3.org/2002/07/owl#"
-   xmlns:rdfatest="http://rdfa.info/vocabs/rdfa-test#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-   xmlns:rel="http://vocab.org/relationship/"
-   xmlns:rsa="http://www.w3.org/ns/auth/rsa#"
-   xmlns:rss="http://web.resource.org/rss/1.0/"
-   xmlns:sioc="http://rdfs.org/sioc/ns#"
-   xmlns:v="http://www.w3.org/2006/vcard/ns#"
-   xmlns:wot="http://xmlns.com/wot/0.1/"
-   xmlns:xhv="http://www.w3.org/1999/xhtml/vocab#"
-   xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+   {"air": "http://www.daml.org/2001/10/html/airport-ont#",
+    "bio": "http://vocab.org/bio/0.1/",
+    "cal": "http://www.w3.org/2002/12/cal/icaltzd#",
+    "cc": "http://creativecommons.org/ns#",
+    "cert": "http://www.w3.org/ns/auth/cert#",
+    "contact": "http://www.w3.org/2000/10/swap/pim/contact#",
+    "dc": "http://purl.org/dc/terms/",
+    "dct": "http://purl.org/dc/terms/",
+    "earl": "http://www.w3.org/ns/earl#",
+    "example": "http://example.org/",
+    "ex": "http://example.org/",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "google": "http://rdf.data-vocabulary.org/#",
+    "ical": "http://www.w3.org/2002/12/cal/icaltzd#",
+    "openid": "http://xmlns.openid.net/auth#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdfatest": "http://rdfa.info/vocabs/rdfa-test#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "rel": "http://vocab.org/relationship/",
+    "rsa": "http://www.w3.org/ns/auth/rsa#",
+    "rss": "http://web.resource.org/rss/1.0/",
+    "sioc": "http://rdfs.org/sioc/ns#",
+    "v": "http://www.w3.org/2006/vcard/ns#",
+    "wot": "http://xmlns.com/wot/0.1/",
+    "xhv": "http://www.w3.org/1999/xhtml/vocab#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"}
 <head>
    <title>RDFa 1.1 Benchmark File #1</title>
 </head>

--- a/tests/0329.txt
+++ b/tests/0329.txt
@@ -1,4 +1,4 @@
-   xmlns:foaf="http://xmlns.com/foaf/0.1/"
+   {"foaf": "http://xmlns.com/foaf/0.1/"}
 <head>
    <title>Test 0329</title>
 </head>

--- a/tests/0330.txt
+++ b/tests/0330.txt
@@ -1,5 +1,5 @@
-   xmlns:dcterms="http://purl.org/dc/terms/"
-   xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+   {"dcterms": "http://purl.org/dc/terms/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"}
 <head>
    <title>Test 0330</title>
 </head>

--- a/tests/0331.txt
+++ b/tests/0331.txt
@@ -1,4 +1,4 @@
-   xmlns:dcterms="http://purl.org/dc/terms/"
+   {"dcterms": "http://purl.org/dc/terms/"}
 <head>
    <title>Test 0331</title>
 </head>


### PR DESCRIPTION
There are a number of existing test cases in the test suite that generate HTML5 output that uses xmlns:foo for prefix mappings, which isn't actually valid in HTML5. This PR changes the test-case sources to use JSON to express the prefix mappings, and changes the backend generation of the serialized mappings from that JSON to be conditional:
- if the output version is RDFa 1.0, then the backend uses the JSON to output@prefix attributes for the mappings
- if the output version is RDFa 1.1, then the backend used the JSON to output xmlns:foo instances for the mappings
