### PR TITLE
Drop xml:base from test 0319; not needed.

### DIFF
--- a/tests/0319.txt
+++ b/tests/0319.txt
@@ -1,6 +1,6 @@
 <head>
   <base href="http://example.com/"></base>
 </head>
-<body xml:base="http://example.com/" prefix="pr: relative/iri#" xmlns:xpr="relative/uri#">
+<body prefix="pr: relative/iri#" xmlns:xpr="relative/uri#">
   <p property="pr:prop xpr:prop">value</p>
 </body>


### PR DESCRIPTION
Without the xml:base, this test seems to still pass for all formats.
