### PR TITLE
Use ".notvalid." instead of ".invalid." for files

### DIFF
--- a/bin/run-suite
+++ b/bin/run-suite
@@ -52,7 +52,7 @@ def run_tc(tc, runner, options)
   STDOUT.write "#{host_language}+#{version} #{tc['num']}: "
 
   if options[:write_file]
-    invalid = host_language.include?('invalid') ? ".invalid" : ""
+    invalid = host_language.include?('invalid') ? ".notvalid" : ""
     if host_language.include?('xhtml')
       filename = tc["num"] + invalid + ".xhtml"
     elsif host_language.include?('html')


### PR DESCRIPTION
"notvalid" is much less likely to be part of a filename in an existing
testsuite. e.g., the ARIA 1.0 test suite has some files that test the
"aria-invalid" attribute, so the filenames for those tests include the
string "invalid"...
