### PR TITLE
Link to the RDFa codelab

### DIFF
--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -55,6 +55,11 @@
 The RDFa Lite document is a quick 15 minute introduction to the basic markup 
 concepts for RDFa Lite.
             </dd>
+            <dt><a href="http://coffeecode.net/rdfa/codelab">Structured data with schema.org codelab</a></dt>
+            <dd>
+This hands-on, hour-long tutorial introduces you to RDFa and the schema.org
+vocabulary.
+            </dd>
             <dt><a href="http://www.w3.org/TR/rdfa-primer/">The RDFa Primer</a></dt>
             <dd>
 The RDFa Primer is a more involved overview of the full power of RDFa.


### PR DESCRIPTION
Per Gregg Kellogg's suggestion at
http://lists.w3.org/Archives/Public/public-rdfa/2014Apr/0011.html, add a link
to the RDFa/schema.org codelab from the rdfa.info/docs page.

Signed-off-by: Dan Scott dan@coffeecode.net
