### PR TITLE
Added the missing default context prefixes to the relevant test.

### DIFF
--- a/tests/0259.sparql
+++ b/tests/0259.sparql
@@ -1,11 +1,19 @@
 ASK WHERE {
-  ?s <http://www.w3.org/2003/g/data-view#> "GRDDL";
+  ?s
+    <http://www.w3.org/ns/csvw#> "CSVW";
+    <http://www.w3.org/ns/dcat#> "DCAT";
+    <http://purl.org/linked-data/cube#> "QB";
+    <http://www.w3.org/2003/g/data-view#> "GRDDL";
     <http://www.w3.org/ns/ma-ont#> "MA";
+    <http://www.w3.org/ns/org#> "ORG";
     <http://www.w3.org/2002/07/owl#> "OWL";
+    <http://www.w3.org/ns/prov#> "PROV";
     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> "RDF";
     <http://www.w3.org/ns/rdfa#> "RDFa";
     <http://www.w3.org/2000/01/rdf-schema#> "RDFS";
     <http://www.w3.org/2007/rif#> "RIF";
+    <http://www.w3.org/ns/r2rml#> "RR";
+    <http://www.w3.org/ns/sparql-service-description#> "SD";
     <http://www.w3.org/2004/02/skos/core#> "SKOS";
     <http://www.w3.org/2008/05/skos-xl#> "SKOS-XL";
     <http://www.w3.org/2007/05/powder#> "WDR";

--- a/tests/0259.txt
+++ b/tests/0259.txt
@@ -4,13 +4,20 @@
 <body>
   <div>
     Vocabulary Prefixes
+    <span property="csvw:">CSVW</span>
+    <span property="dcat:">DCAT</span>
+    <span property="qb:">QB</span>
     <span property="grddl:">GRDDL</span>
     <span property="ma:">MA</span>
+    <span property="org:">ORG</span>ORG
     <span property="owl:">OWL</span>
+    <span property="prov:">PROV</span>
     <span property="rdf:">RDF</span>
     <span property="rdfa:">RDFa</span>
     <span property="rdfs:">RDFS</span>
     <span property="rif:">RIF</span>
+    <span property="rr:">RR</span>
+    <span property="sd:">SD</span>
     <span property="skos:">SKOS</span>
     <span property="skosxl:">SKOS-XL</span>
     <span property="wdr:">WDR</span>


### PR DESCRIPTION
Missing prefixes were: csvw, dcat, qb, org, prov, rr, sd